### PR TITLE
Allow insecure network connections

### DIFF
--- a/thesarvo-android/guide/src/main/AndroidManifest.xml
+++ b/thesarvo-android/guide/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
         android:icon="@drawable/thesarvoapplogo"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
-        android:name="com.thesarvo.guide.GuideApplication">
+        android:name="com.thesarvo.guide.GuideApplication"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <activity
             android:name=".MainActivity"
@@ -94,6 +95,7 @@
     <uses-permission android:name="com.android.vending.CHECK_LICENSE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-feature
         android:glEsVersion="0x00020000"

--- a/thesarvo-android/guide/src/main/res/xml/network_security_config.xml
+++ b/thesarvo-android/guide/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">www.thesarvo.com</domain>
+        <domain includeSubdomains="true">bom.gov.au</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
-By default Android no longer supports HTTP requests. thesarvo.com doesn't
seem to support https (at least not for the resources the app needs), so
exceptions have been added for the thesarvo.com domain. Exceptions have
also been added for the BOM domain, as the weather stuff refers to the
http:// address. This can probably be fixed by just changing the links
in the Weather page.